### PR TITLE
limit parallel goroutines

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ import (
 	"github.com/ksdfg/workgroup"
 )
 
-// Search for substrings parallelly
+// Search for substrings in parallel
 func main() {
 	// Declare phrase and keywords to search in phrase
 	phrase := "A small utility to manage the lifetime of a set of related goroutines."
@@ -80,8 +80,8 @@ func main() {
 		)
 	}
 
-	// Call Run to search for keywords parallelly
-	output := workgroup.Run(fns)
+	// Call Run to search for keywords in parallel, with a maximum of 3 goroutines running at a time
+	output := workgroup.Run(fns, 3)
 	fmt.Println(output, "found")
 }
 ```
@@ -98,13 +98,13 @@ import (
 	"github.com/ksdfg/workgroup"
 )
 
-// Search for substrings parallelly
+// Search for substrings in parallel
 func main() {
 	// Declare phrase and keywords to search in phrase
 	phrase := "A small utility to manage the lifetime of a set of related goroutines."
 	keywords := []string{"function", "variable", "slice", "goroutine", "package"}
 
-	// Call RunTemplate to search for keywords parallelly
+	// Call RunTemplate to search for keywords in parallel, with a maximum of 3 goroutines running at a time
 	// Pass number of keywords as n
 	// In the template function, check if the ith keyword is a substring in the phrase
 	// Return the keyword if it is found
@@ -118,6 +118,7 @@ func main() {
 			}
 			return k
 		},
+		3,
 	)
 	fmt.Println(output, "found")
 }

--- a/example_test.go
+++ b/example_test.go
@@ -31,8 +31,8 @@ func ExampleRun() {
 		)
 	}
 
-	// Call Run to search for keywords parallelly
-	output := workgroup.Run(fns)
+	// Call Run to search for keywords in parallel
+	output := workgroup.Run(fns, 3)
 	fmt.Println(output, "found")
 	// Output:
 	// goroutine found
@@ -43,7 +43,7 @@ func ExampleRunTemplate() {
 	phrase := "A small utility to manage the lifetime of a set of related goroutines."
 	keywords := []string{"function", "variable", "slice", "goroutine", "package"}
 
-	// Call RunTemplate to search for keywords parallelly
+	// Call RunTemplate to search for keywords in parallel
 	// Pass number of keywords as n
 	// In the template function, check if the ith keyword is a substring in the phrase
 	// Return the keyword if it is found

--- a/example_test.go
+++ b/example_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"workgroup"
+	"github.com/ksdfg/workgroup"
 )
 
 func ExampleRun() {

--- a/example_test.go
+++ b/example_test.go
@@ -57,6 +57,7 @@ func ExampleRunTemplate() {
 			}
 			return k
 		},
+		3,
 	)
 	fmt.Println(output, "found")
 	// Output:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module workgroup
+module github.com/ksdfg/workgroup
 
 go 1.16

--- a/workgroup.go
+++ b/workgroup.go
@@ -65,15 +65,15 @@ func Run(fns []func() interface{}, maxParallelGoroutines int) interface{} {
 
 		// Wait for all goroutines to end execution.
 		wg.Wait()
+
+		// Return output from first function to end execution.
+		if len(output) > 0 {
+			return <-output
+		}
 	}
 
-	// Return output from first function to end execution.
 	// If no output has been sent to channel, return nil.
-	if len(output) > 0 {
-		return <-output
-	} else {
-		return nil
-	}
+	return nil
 }
 
 /*
@@ -133,13 +133,13 @@ func RunTemplate(n int, template func(int) interface{}, maxParallelGoroutines in
 
 		// Wait for all goroutines to end execution.
 		wg.Wait()
+
+		// Return output from first function to end execution.
+		if len(output) > 0 {
+			return <-output
+		}
 	}
 
-	// Return output from first function to end execution.
 	// If no output has been sent to channel, return nil.
-	if len(output) > 0 {
-		return <-output
-	} else {
-		return nil
-	}
+	return nil
 }

--- a/workgroup.go
+++ b/workgroup.go
@@ -85,46 +85,55 @@ The return value from the first function will be returned to the caller of RunTe
 If none of the functions return a non-nil value, all the spawned goroutines will naturally end execution and
 RunTemplate will return nil.
 */
-func RunTemplate(n int, template func(int) interface{}) interface{} {
+func RunTemplate(n int, template func(int) interface{}, maxParallelGoroutines int) interface{} {
 	// Make channel to receive output from the goroutines.
 	// We're using a channel instead of setting a variable to ensure that the first value returned by a goroutine
 	// is what this function returns.
 	output := make(chan interface{}, 1)
 	defer close(output)
 
-	// Make a wait group and set delta to number of times the template function needs to be run.
-	var wg sync.WaitGroup
-	wg.Add(n)
-
-	// Make a context with cancel to stop all other goroutines once a function ends it's execution.
+	// Make a context with cancel to stop all other goroutines once a function ends its execution.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Run the template function n number of times in individual goroutines.
-	for i := 0; i < n; i++ {
-		go func(fn func(int) interface{}, output chan<- interface{}, index int) {
-			// Reduce delta of wait group by 1 when execution of goroutine is done or cancelled.
-			defer wg.Done()
+	for i := 0; i < n; i += maxParallelGoroutines {
+		// Calculate bounds for inner for loop to start batch of goroutines
+		start := i
+		end := i + maxParallelGoroutines
+		if end > n {
+			end = n
+		}
 
-			select {
-			// End execution when cancel is called by another goroutine.
-			case <-ctx.Done():
-				return
+		// Make a wait group and set delta to number of times the template function needs to be run.
+		var wg sync.WaitGroup
+		wg.Add(end - start)
 
-			// If cancel has not been called, run the template function and pass index.
-			default:
-				op := fn(index)
-				// If returned value is not nil, send output to channel.
-				if op != nil {
-					output <- op
-					cancel()
+		// Run the template function n number of times in individual goroutines.
+		for j := start; j < end; j++ {
+			go func(fn func(int) interface{}, output chan<- interface{}, index int) {
+				// Reduce delta of wait group by 1 when execution of goroutine is done or cancelled.
+				defer wg.Done()
+
+				select {
+				// End execution when cancel is called by another goroutine.
+				case <-ctx.Done():
+					return
+
+				// If cancel has not been called, run the template function and pass index.
+				default:
+					op := fn(index)
+					// If returned value is not nil, send output to channel.
+					if op != nil {
+						output <- op
+						cancel()
+					}
 				}
-			}
-		}(template, output, i)
-	}
+			}(template, output, j)
+		}
 
-	// Wait for all goroutines to end execution.
-	wg.Wait()
+		// Wait for all goroutines to end execution.
+		wg.Wait()
+	}
 
 	// Return output from first function to end execution.
 	// If no output has been sent to channel, return nil.

--- a/workgroup.go
+++ b/workgroup.go
@@ -28,12 +28,12 @@ func Run(fns []func() interface{}, maxParallelGoroutines int) interface{} {
 	defer cancel()
 
 	// Run functions in batches according to max parallel goroutines specified in arguments
-	for i := 0; i < len(fns)-1; i += maxParallelGoroutines {
+	for i := 0; i < len(fns); i += maxParallelGoroutines {
 		// Calculate indexes to slice the functions array
 		start := i
 		end := i + maxParallelGoroutines
-		if end >= len(fns) {
-			end = len(fns) - 1
+		if end > len(fns) {
+			end = len(fns)
 		}
 
 		// Make a wait group and set delta to number of functions to run.

--- a/workgroup.go
+++ b/workgroup.go
@@ -16,46 +16,56 @@ The return value from the first function will be returned to the caller of Run.
 If none of the functions return a non-nil value, all the spawned goroutines will naturally end execution and
 Run will return nil.
 */
-func Run(fns []func() interface{}) interface{} {
+func Run(fns []func() interface{}, maxParallelGoroutines int) interface{} {
 	// Make channel to receive output from the goroutines.
 	// We're using a channel instead of setting a variable to ensure that the first value returned by a goroutine
 	// is what this function returns.
 	output := make(chan interface{}, 1)
 	defer close(output)
 
-	// Make a wait group and set delta to number of functions to run.
-	var wg sync.WaitGroup
-	wg.Add(len(fns))
-
-	// Make a context with cancel to stop all other goroutines once a function ends it's execution.
+	// Make a context with cancel to stop all other goroutines once a function ends its execution.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Run all functions in goroutines.
-	for _, fn := range fns {
-		go func(fn func() interface{}, output chan<- interface{}) {
-			// Reduce delta of wait group by 1 when execution of goroutine is done or cancelled.
-			defer wg.Done()
+	// Run functions in batches according to max parallel goroutines specified in arguments
+	for i := 0; i < len(fns)-1; i += maxParallelGoroutines {
+		// Calculate indexes to slice the functions array
+		start := i
+		end := i + maxParallelGoroutines
+		if end >= len(fns) {
+			end = len(fns) - 1
+		}
 
-			select {
-			// End execution when cancel is called by another goroutine.
-			case <-ctx.Done():
-				return
+		// Make a wait group and set delta to number of functions to run.
+		var wg sync.WaitGroup
+		wg.Add(end - start)
 
-			// If cancel has not been called, run the function.
-			default:
-				op := fn()
-				// If returned value is not nil, send output to channel.
-				if op != nil {
-					output <- op
-					cancel()
+		// Run all functions in goroutines.
+		for _, fn := range fns[start:end] {
+			go func(fn func() interface{}, output chan<- interface{}) {
+				// Reduce delta of wait group by 1 when execution of goroutine is done or cancelled.
+				defer wg.Done()
+
+				select {
+				// End execution when cancel is called by another goroutine.
+				case <-ctx.Done():
+					return
+
+				// If cancel has not been called, run the function.
+				default:
+					op := fn()
+					// If returned value is not nil, send output to channel.
+					if op != nil {
+						output <- op
+						cancel()
+					}
 				}
-			}
-		}(fn, output)
-	}
+			}(fn, output)
+		}
 
-	// Wait for all goroutines to end execution.
-	wg.Wait()
+		// Wait for all goroutines to end execution.
+		wg.Wait()
+	}
 
 	// Return output from first function to end execution.
 	// If no output has been sent to channel, return nil.

--- a/workgroup_test.go
+++ b/workgroup_test.go
@@ -104,6 +104,7 @@ func TestRunTemplateEmptySlice(t *testing.T) {
 		func(_ int) interface{} {
 			return nil
 		},
+		3,
 	)
 	if output != nil {
 		t.Fatalf("expected: %v\ngot: %v", nil, output)
@@ -123,6 +124,7 @@ func TestRunTemplateSearchSubstringSuccess(t *testing.T) {
 			}
 			return k
 		},
+		3,
 	)
 	if output != "cat" {
 		t.Fatalf("expected: cat\ngot: %v", output)
@@ -142,6 +144,7 @@ func TestRunTemplateSearchSubstringFailure(t *testing.T) {
 			}
 			return k
 		},
+		3,
 	)
 	if output != nil {
 		t.Fatalf("expected: %v\ngot: %v", nil, output)
@@ -161,6 +164,7 @@ func TestRunTemplateSearchSubstringSuccessMany(t *testing.T) {
 			}
 			return k
 		},
+		3,
 	)
 	if output != "cat" && output != "meow" {
 		t.Fatalf("expected: 'cat' or 'meow'\ngot: %v", output)

--- a/workgroup_test.go
+++ b/workgroup_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"workgroup"
+	"github.com/ksdfg/workgroup"
 )
 
 /*

--- a/workgroup_test.go
+++ b/workgroup_test.go
@@ -21,7 +21,7 @@ func TestRunEmptySlice(t *testing.T) {
 
 func TestRunSearchSubstringSuccess(t *testing.T) {
 	phrase := "Neko-chan the cat goes meow."
-	keywords := []string{"dog", "camel", "horse", "cat", "wolf", "fox", "tiger"}
+	keywords := []string{"dog", "camel", "horse", "wolf", "fox", "tiger", "cat"}
 
 	var fns []func() interface{}
 	for _, keyword := range keywords {

--- a/workgroup_test.go
+++ b/workgroup_test.go
@@ -13,7 +13,7 @@ Tests for Run
 
 func TestRunEmptySlice(t *testing.T) {
 	var slice []func() interface{}
-	output := workgroup.Run(slice)
+	output := workgroup.Run(slice, 3)
 	if output != nil {
 		t.Fatalf("expected: %v\ngot: %v", nil, output)
 	}
@@ -38,7 +38,7 @@ func TestRunSearchSubstringSuccess(t *testing.T) {
 		)
 	}
 
-	output := workgroup.Run(fns)
+	output := workgroup.Run(fns, 3)
 	if output != "cat" {
 		t.Fatalf("expected: cat\ngot: %v", output)
 	}
@@ -63,7 +63,7 @@ func TestRunSearchSubstringFailure(t *testing.T) {
 		)
 	}
 
-	output := workgroup.Run(fns)
+	output := workgroup.Run(fns, 3)
 	if output != nil {
 		t.Fatalf("expected: %v\ngot: %v", nil, output)
 	}
@@ -88,7 +88,7 @@ func TestRunSearchSubstringSuccessMany(t *testing.T) {
 		)
 	}
 
-	output := workgroup.Run(fns)
+	output := workgroup.Run(fns, 3)
 	if output != "cat" && output != "meow" {
 		t.Fatalf("expected: 'cat' or 'meow'\ngot: %v", output)
 	}


### PR DESCRIPTION
The current implementations of the `Run` and `RunTemplate` functions are extremely dangerous, since they allow users to pass in extremely large arrays / n values and spawn a large number of goroutines in one go.
In order to support executing workgroups of large arrays but maintain safety of the system so that we don't overload the hardware, the easiest way was to run batches of goroutines internally wit a max parallel goroutines accepted as an argument to the functions.
